### PR TITLE
Fix bytestr pass to calcLength

### DIFF
--- a/PoisonIvy.py
+++ b/PoisonIvy.py
@@ -69,7 +69,7 @@ def dataWalk(splitdata):
 	maxCount = 0
 	while offset < EOF and maxCount < 22:
 		try:
-			length = calcLength(stream[offset+2:offset+4])
+			length = calcLength(str(stream[offset+2:offset+4]))
 			temp = []
 			for i in range(offset+4, offset+4+length):
 				temp.append(chr(stream[i]))


### PR DESCRIPTION
Fix exception caused by passing bytestr instead of str to calcLength.
Was causing exception on the first config value and an “empty” config
to be return in python 2.7
