### PR TITLE
Remove findUSStream unintentional return

### DIFF
--- a/njRat.py
+++ b/njRat.py
@@ -61,8 +61,7 @@ def findUSStream(pe, dir):
 		name = pe.ntHeaders.optionalHeader.dataDirectory[dir].info.netMetaDataStreams[i].name.value
 		if name.startswith("#US"):
 			return pe.ntHeaders.optionalHeader.dataDirectory[dir].info.netMetaDataStreams[i].info
-		else:
-			return None
+	return None
 
 #Walk the User Strings and create a list of individual strings
 def parseStrings(rawConfig):


### PR DESCRIPTION
Code always returned on first iteration of loop, causing it to never
find the #US stream. Now only returns None once it has gone through all
of the streams and has not found #US
