### PR TITLE
Modify encoding for open README to prevent ascii errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from setuptools import setup, find_packages
 
-with open("README.md", "r") as fh:
+with open("README.md", encoding='utf8') as fh:
     long_description = fh.read()
 
 setup(


### PR DESCRIPTION
When attempting to install the tool without cloning, using pip3 install git+https://github.com/kevthehermit/RATDecoders, users are occasionally met with an ascii error: 
`UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 2222: ordinal not in range(128)`
This is due to python not interpreting the encoding of the README identified in setup.py as utf8.

This change will force the encoding to be utf8 and allow for the pip3 install without cloning the repo.