### PR TITLE
The Decoder for current RedLine Stealer Versions

### DIFF
--- a/malwareconfig/decoders/RedLine.py
+++ b/malwareconfig/decoders/RedLine.py
@@ -1,0 +1,55 @@
+from malwareconfig.common import Decoder
+from malwareconfig.common import string_printable
+import base64
+
+
+
+
+
+
+class RedLine(Decoder):
+    decoder_name = "RedLine"
+    decoder__version = 1
+    decoder_author = "@Gi7w0rm"
+    decoder_description = "RedLine RAT Decoder"
+
+    def __init__(self):
+        self.config = {}
+
+
+    def get_config(self):
+        '''
+        This is the main entry
+        :return:
+        '''
+        config_dict = {}
+
+        user_strings = self.file_info.dotnet_user_strings()
+        base_location = user_strings.index("Yandex\\YaAddon")
+        enc_domain = user_strings[base_location+1]
+        enc_ID = user_strings[base_location+2]
+        enc_key = user_strings[base_location+3]
+        config_dict['Config_Key'] = enc_key    
+        config_dict['C2_Proxy'] = self.decrypt(enc_domain, enc_key)
+        config_dict['Campaign_ID'] = self.decrypt(enc_ID, enc_key)
+
+        # Set the config to the class for use
+        self.config = config_dict
+
+    def decrypt(self, str_to_dec, Key):
+        dec_xor = ""
+        first_dec = base64.b64decode(str_to_dec)
+    
+        len_first_dec = len(first_dec)
+
+
+        for i in range(len_first_dec):
+            Key = Key + str(Key[i % len(Key)])
+
+        a_list = [chr(ord(chr(a)) ^ ord(b)) for a,b in zip(first_dec, Key)]
+        dec_xor = "".join(a_list)
+        third_dec = base64.b64decode(dec_xor)
+        tocut = str(third_dec)
+        cut = tocut[2:-1]
+        return cut    
+


### PR DESCRIPTION
Working examples SHA-256:
 0193e29baf9746fc70bb078b954de75153adb46cb93f9342f059bf8adab98040
and
9174bf148a5bb3d8c7e99b3df2508006d3d80d4a980ff25ba4bee63f029ab100