### PR TITLE
Use an updated version of the crypto library

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ There are some pre-reqs that are included in the pip setup and the requirements.
 - pefile
 - pbkdf2
 - javaobj-py3
-- pycrypto
+- pycryptodome
 - androguard
 
 For all the decoders you will need yara and yara-python. For dealing with .NET malware you will need to install yara-python with dotnet support

--- a/malwareconfig/crypto.py
+++ b/malwareconfig/crypto.py
@@ -1,5 +1,6 @@
+import itertools
 import struct
-from Crypto.Cipher import ARC4, DES, DES3, AES, Blowfish, XOR
+from Crypto.Cipher import ARC4, DES, DES3, AES, Blowfish
 from Crypto.PublicKey import RSA
 
 from pbkdf2 import PBKDF2
@@ -13,8 +14,7 @@ def decrypt_rsa(key, data):
 
 # XOR
 def decrypt_xor(key, data):
-    cipher = XOR.new(key)
-    return cipher.decrypt(data)
+    return bytes([a ^ b for a, b in zip(itertools.cycle(key), data)])
 
 
 # RC4

--- a/malwareconfig/decoders/sakula.py
+++ b/malwareconfig/decoders/sakula.py
@@ -67,7 +67,7 @@ class Sakula(Decoder):
         # RE for 1.2, 1.3, 1.4
         re_pattern2 = b'([ -~]{50})([ -~]{50})([ -~]{50})([ -~]{50})([ -~]{50})([ -~]{50})([ -~]{50})([ -~]{50})([ -~]{12})(0uVVVVVV)'
 
-        xor_data = crypto.decrypt_xor('\x88', file_data)
+        xor_data = crypto.decrypt_xor(b'\x88', file_data)
 
         config_list = re.findall(re_pattern1, xor_data)
 
@@ -77,7 +77,7 @@ class Sakula(Decoder):
 
         # XOR for later versions
 
-        xor_data = crypto.decrypt_xor('V', file_data)
+        xor_data = crypto.decrypt_xor(b'V', file_data)
 
         config_list = re.findall(re_pattern2, xor_data)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pefile
 pbkdf2
 javaobj-py3
-pycrypto
+pycryptodome
 androguard


### PR DESCRIPTION
The pycryto library used in the requirements.txt file has been deprecated for about 9 years and contains security vulnerabilites.

This PR updates the requirements.txt and the main crypto module as well as the only decoder I could find that was using the XOR function of the crypto module. I've use the proposed function in issue #50 as the XOR function.