### PR TITLE
Added ports to control server addresses

### DIFF
--- a/malwareconfig/decoders/mirai.py
+++ b/malwareconfig/decoders/mirai.py
@@ -38,7 +38,7 @@ class Mirai(Decoder):
 
         regex_domain = re.compile(rb"(?!:\/\/)[a-zA-Z0-9-_]+\.*[a-zA-Z0-9][a-zA-Z0-9-_]+\.[a-zA-Z]{2,11}", re.IGNORECASE)
         regex_ip = re.compile(rb'(?:[0-9]{1,3}\.){3}[0-9]{1,3}', re.IGNORECASE)
-
+        xor_key = 0
 
         match_words = [b'iptables', b'busybox', b'Mozilla']
         false_postive_c2 = [b'resolv.conf', b'schemas.xmlsoap.org', b'tftp.sh']
@@ -54,10 +54,24 @@ class Mirai(Decoder):
                 for c2 in domain_results:
                     # Sometimes some xor keys can be a bit annoying. 
                     if c2 not in false_postive_c2:
-                        c2_list.append(c2.decode('utf-8'))
+                        c2_index = xor_data.index(c2)
+                        buf = xor_data[c2_index:c2_index+256]
+                        rport = b"".join(buf.split(i.to_bytes(1, 'big'))[3:5])
+                        if len(rport) == 2: 
+                            port = unpack('>H', rport)[0]
+                            if port <= 65535 and port > 1:
+                                c2_list.append("{}:{}".format(c2.decode('utf-8'),port))
+
+
                 for c2 in ip_results:
-                    if c2 not in false_postive_c2:
-                        c2_list.append(c2.decode('utf-8'))
+                        c2_index = xor_data.index(c2)
+                        buf = xor_data[c2_index:c2_index+256]
+                        rport = b"".join(buf.split(i.to_bytes(1, 'big'))[3:5])
+                        if len(rport) > 0 and len(rport) <= 4:
+                            port = unpack('>H', rport)[0]
+                            if port <= 65535 and port > 1:
+                                c2_list.append("{}:{}".format(c2.decode('utf-8'),port))
+
 
         config_dict['Commment'] = "The C2 extraction uses a best effort xor decryption. There may be issues with some xor keys like 0x78"
         config_dict['C2'] = c2_list


### PR DESCRIPTION
I'll be the first to admit this isn't perfect.  

Typically, the port for each C2/Reporting server is stored in the two bytes following the (address + null bytes).  As two are defined in `mirai/bot/table.c` ([ref](https://github.com/jgamblin/Mirai-Source-Code/blob/master/mirai/bot/table.c)) as `TABLE_CNC_DOMAIN`  and `TABLE_CNC_PORT`, I'm assuming the compiler just sequentially processes variables for some(?) architectures. Example below:


```
00013520: 7222 3add d222 2222 ddd9 3d22 2222 2222  r":.."""..="""""
00013530: 636e 632e 6368 616e 6765 6d65 2e63 6f6d  cnc.changeme.com
00013540: 0022 2222 0017 2222 7265 706f 7274 2e63  ."""..""report.c
00013550: 6861 6e67 656d 652e 636f 6d00 2222 2222  hangeme.com.""""
00013560: bbe5 2222 6c69 7374 656e 696e 6720 7475  ..""listening tu
00013570: 6e30 0022 6874 7470 733a 2f2f 796f 7574  n0."https://yout
00013580: 752e 6265 2f64 5177 3477 3957 6758 6351  u.be/dQw4w9WgXcQ
```

` 'C2': ['cnc.changeme.com:23', 'report.changeme.com:48101'],`